### PR TITLE
feat: Add Docker Compose configuration for Loki, Promtail, and Grafana

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -21,8 +21,8 @@ services:
     image: grafana/promtail:latest
     volumes:
       - /home/javi/dev/tfg/log:/var/log
-      - /home/javi/dev/tfg/docker/promtail-config.yaml:/etc/promtail/promtail-config.yaml
-    command: -config.file=/etc/promtail/promtail-config.yaml
+      - /home/javi/dev/tfg/docker/promtail-config.yaml:/etc/promtail/config.yml
+    command: -config.file=/etc/promtail/config.yml -config.expand-env=true
     networks:
       - loki
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -20,8 +20,8 @@ services:
   promtail:
     image: grafana/promtail:latest
     volumes:
-      - /home/javi/dev/tfg/log:/var/log
-      - /home/javi/dev/tfg/docker/promtail-config.yaml:/etc/promtail/config.yml
+      - /home/javi/dev/US-TFG-PlanifyAPI-Python/log:/var/log
+      - /home/javi/dev/US-TFG-PlanifyAPI-Python/docker/promtail-config.yaml:/etc/promtail/config.yml
     command: -config.file=/etc/promtail/config.yml -config.expand-env=true
     networks:
       - loki

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,36 @@
+version: "3"
+
+networks:
+  loki:
+
+volumes:
+  grafana-data:
+
+services:
+  loki:
+    image: grafana/loki:latest
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+    volumes:
+      - /home/javi/dev/tfg/docker/loki-config.yaml:/etc/loki/local-config.yaml
+    networks:
+      - loki
+
+  promtail:
+    image: grafana/promtail:latest
+    volumes:
+      - /home/javi/dev/tfg/log:/var/log
+      - /home/javi/dev/tfg/docker/promtail-config.yaml:/etc/promtail/promtail-config.yaml
+    command: -config.file=/etc/promtail/promtail-config.yaml
+    networks:
+      - loki
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana-data:/var/lib/grafana
+    networks:
+      - loki

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "3"
+version: '3'
 
 networks:
   loki:
@@ -10,7 +10,7 @@ services:
   loki:
     image: grafana/loki:latest
     ports:
-      - "3100:3100"
+      - '3100:3100'
     command: -config.file=/etc/loki/local-config.yaml
     volumes:
       - /home/javi/dev/US-TFG-PlanifyAPI-Python/docker/loki-config.yaml:/etc/loki/local-config.yaml
@@ -20,7 +20,8 @@ services:
   promtail:
     image: grafana/promtail:latest
     volumes:
-      - /home/javi/dev/US-TFG-PlanifyAPI-Python/log:/var/log
+      - /home/javi/dev/US-TFG-PlanifyAPI-Python/log:/var/log/alberto
+      - /home/javi/dev/US-TFG-PlanifyAPI-Python/PlanifyAPI-base/log:/var/log/javi
       - /home/javi/dev/US-TFG-PlanifyAPI-Python/docker/promtail-config.yaml:/etc/promtail/config.yml
     command: -config.file=/etc/promtail/config.yml -config.expand-env=true
     networks:
@@ -29,7 +30,7 @@ services:
   grafana:
     image: grafana/grafana:latest
     ports:
-      - "3000:3000"
+      - '3000:3000'
     volumes:
       - grafana-data:/var/lib/grafana
     networks:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       - "3100:3100"
     command: -config.file=/etc/loki/local-config.yaml
     volumes:
-      - /home/javi/dev/tfg/docker/loki-config.yaml:/etc/loki/local-config.yaml
+      - /home/javi/dev/US-TFG-PlanifyAPI-Python/docker/loki-config.yaml:/etc/loki/local-config.yaml
     networks:
       - loki
 

--- a/docker/loki-config.yaml
+++ b/docker/loki-config.yaml
@@ -1,0 +1,50 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /tmp/loki
+  storage:
+    filesystem:
+      chunks_directory: /tmp/loki/chunks
+      rules_directory: /tmp/loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+# By default, Loki will send anonymous, but uniquely-identifiable usage and configuration
+# analytics to Grafana Labs. These statistics are sent to https://stats.grafana.org/
+#
+# Statistics help us better understand how Loki is used, and they show us performance
+# levels for most users. This helps us prioritize features and documentation.
+# For more information on what's sent, look at
+# https://github.com/grafana/loki/blob/main/pkg/usagestats/stats.go
+# Refer to the buildReport method to see what goes into a report.
+#
+# If you would like to disable reporting, uncomment the following lines:
+#analytics:
+#  reporting_enabled: false

--- a/docker/loki-config.yaml
+++ b/docker/loki-config.yaml
@@ -21,7 +21,7 @@ query_range:
     cache:
       embedded_cache:
         enabled: true
-        max_size_mb: 100
+        max_size_mb: 10000
 
 schema_config:
   configs:
@@ -39,6 +39,8 @@ ruler:
 limits_config:
   reject_old_samples_max_age: 43800h
   reject_old_samples: false
+  ingestion_rate_mb: 20000
+  ingestion_burst_size_mb: 30000
 # By default, Loki will send anonymous, but uniquely-identifiable usage and configuration
 # analytics to Grafana Labs. These statistics are sent to https://stats.grafana.org/
 #

--- a/docker/loki-config.yaml
+++ b/docker/loki-config.yaml
@@ -36,6 +36,9 @@ schema_config:
 ruler:
   alertmanager_url: http://localhost:9093
 
+limits_config:
+  reject_old_samples_max_age: 43800h
+  reject_old_samples: false
 # By default, Loki will send anonymous, but uniquely-identifiable usage and configuration
 # analytics to Grafana Labs. These statistics are sent to https://stats.grafana.org/
 #

--- a/docker/promtail-config.yaml
+++ b/docker/promtail-config.yaml
@@ -9,13 +9,29 @@ clients:
   - url: http://loki:3100/loki/api/v1/push
 
 scrape_configs:
-  - job_name: system
+  - job_name: varlogs-alberto
     static_configs:
       - targets:
           - localhost
         labels:
-          job: varlogs
-          __path__: /var/log/*/*_filtered.json
+          job: varlogs-alberto
+          __path__: /var/log/alberto/*/*_filtered.json
+    pipeline_stages:
+      - json:
+          expressions:
+            timestamp: timestamp
+            level: level
+            description: description
+      - timestamp:
+          source: timestamp
+          format: Unix
+  - job_name: varlogs-javi
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: varlogs-javi
+          __path__: /var/log/javi/*/*_filtered.json
     pipeline_stages:
       - json:
           expressions:

--- a/docker/promtail-config.yaml
+++ b/docker/promtail-config.yaml
@@ -15,7 +15,7 @@ scrape_configs:
           - localhost
         labels:
           job: varlogs
-          __path__: /var/log/amadeus__r_ft_/*json
+          __path__: /var/log/*/*_filtered.json
     pipeline_stages:
       - json:
           expressions:

--- a/docker/promtail-config.yaml
+++ b/docker/promtail-config.yaml
@@ -1,0 +1,18 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: varlogs
+          __path__: /var/log/*/*log

--- a/docker/promtail-config.yaml
+++ b/docker/promtail-config.yaml
@@ -15,4 +15,13 @@ scrape_configs:
           - localhost
         labels:
           job: varlogs
-          __path__: /var/log/*/*log
+          __path__: /var/log/amadeus__r_ft_/*json
+    pipeline_stages:
+      - json:
+          expressions:
+            timestamp: timestamp
+            level: level
+            description: description
+      - timestamp:
+          source: timestamp
+          format: Unix


### PR DESCRIPTION
## Descripción del Cambio

Se han creado los ficheros `docker-compose.yaml` para configurar **Grafana**, **Loki** y **Promtail**, junto con los archivos de configuración `loki-config.yaml` y `promtail-config.yaml`. Estos archivos permiten desplegar y configurar los servicios de monitoreo **Grafana**, **Loki** y **Promtail** de manera integrada utilizando `docker-compose`.

Al final añado los Gráficos que han ido saliendo.

## Problema Relacionado

Este pull request no soluciona un problema específico, sino que proporciona una configuración inicial para desplegar los servicios de monitoreo mencionados.

## Tipo de Cambio

- [ ] Corrección de error (bugfix)
- [x] Nueva característica (feature)
- [ ] Mejora de rendimiento (performance improvement)
- [ ] Cambio estructural (structural change)
- [ ] Actualización de dependencias (dependency update)
- [ ] Otro (especifique)

## Pruebas Realizadas

Se han realizado las siguientes pruebas para verificar el funcionamiento correcto de los cambios:

- Se ha ejecutado `docker-compose up -d` para verificar que los servicios se despliegan correctamente.
- Se ha accedido a **Grafana** a través del navegador web para asegurar que se puede acceder al panel de control.
- Se ha comprobado que **Loki** y **Promtail** están funcionando correctamente y recopilando registros.

## Lista de Verificación

- [x] He leído y seguido las pautas de contribución del proyecto.
- [x] Mi código sigue los estándares de codificación del proyecto.
- [ ] He realizado cambios en la documentación si es necesario.
- [ ] He actualizado los archivos de prueba si corresponde.
- [x] Mis cambios no introducen nuevas advertencias ni errores en las pruebas.
- [x] He revisado visualmente mis cambios para asegurarme de que se ven como se esperaba.

## Dashboards Realizados
![image](https://github.com/PlanifyAPI/US-TFG-PlanifyAPI-Python/assets/72880234/9ebf4947-a1c4-4b7f-8241-3c6c022f5dde)

